### PR TITLE
Feature/solr7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.factual.solr.indexing</groupId>
     <artifactId>solr-mapreduce-indexer</artifactId>
     <name>solr-mapreduce-indexer</name>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.0</version>
     <dependencies>    
         <dependency>
             <groupId>net.sourceforge.argparse4j</groupId>
@@ -34,13 +34,13 @@
         <dependency>
             <groupId>com.factual</groupId>
             <artifactId>shaded-solr</artifactId>
-            <version>7.7.2.6-SNAPSHOT</version>
+            <version>7.7.2.6</version>
             <type>jar</type>
         </dependency>
         <dependency>
             <groupId>com.factual.solr.indexing</groupId>
             <artifactId>solr-morphlines-shaded</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>1.0.0</version>
             <type>jar</type>
         </dependency>
 

--- a/solr-morphlines-shaded/pom.xml
+++ b/solr-morphlines-shaded/pom.xml
@@ -6,7 +6,7 @@
   <groupId>com.factual.solr.indexing</groupId>
   <artifactId>solr-morphlines-shaded</artifactId>
   <name>solr-morphlines-shaded</name>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>1.0.0</version>
   <properties>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/src/main/java/org/apache/solr/hadoop/IndexMergeTool.java
+++ b/src/main/java/org/apache/solr/hadoop/IndexMergeTool.java
@@ -71,7 +71,7 @@ public class IndexMergeTool extends Configured implements Tool {
         options.fanout = Math.min(options.fanout, (int) Utils.ceilDivide(numInputShards, options.shards));
         return merge(conf, options, numInputShards);
       } else {
-        LOG.info("Merging {} input shards into {} shards has no effect.", numInputShards, options.shards);
+        LOG.info("Merging {} input shards into {} shards has no effect. Input:{}", numInputShards, options.shards, options.inputDir);
         return true;
       }
     }

--- a/src/main/java/org/apache/solr/hadoop/SolrOutputFormat.java
+++ b/src/main/java/org/apache/solr/hadoop/SolrOutputFormat.java
@@ -70,6 +70,10 @@ public class SolrOutputFormat<K, V> extends FileOutputFormat<K, V> {
    */
   public static final String OUTPUT_ZIP_FILE = "solr.output.zip.format";
 
+  public static final String SOLR_XML_FILE = "solr.xml";
+
+  public static final String SOLR_XML_CONTENTS = "<solr></solr>";
+
   static int defaultSolrWriterThreadCount = 0;
 
   public static final String SOLR_WRITER_THREAD_COUNT = "solr.record.writer.num.threads";
@@ -244,9 +248,9 @@ public class SolrOutputFormat<K, V> extends FileOutputFormat<K, V> {
       zos.closeEntry();
     }
     
-    ZipEntry ze = new ZipEntry("solr.xml");
+    ZipEntry ze = new ZipEntry(SOLR_XML_FILE);
     zos.putNextEntry(ze);
-    zos.write("<solr></solr>".getBytes("UTF-8"));
+    zos.write(SOLR_XML_CONTENTS.getBytes("UTF-8"));
     zos.flush();
     zos.closeEntry();
     zos.close();

--- a/src/main/java/org/apache/solr/hadoop/SolrRecordWriter.java
+++ b/src/main/java/org/apache/solr/hadoop/SolrRecordWriter.java
@@ -16,6 +16,7 @@
  */
 package org.apache.solr.hadoop;
 
+import org.apache.hadoop.mapreduce.*;
 import org.apache.solr.hadoop.util.HeartBeater;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
@@ -35,10 +36,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.filecache.DistributedCache;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.mapreduce.RecordWriter;
-import org.apache.hadoop.mapreduce.Reducer;
-import org.apache.hadoop.mapreduce.TaskAttemptContext;
-import org.apache.hadoop.mapreduce.TaskID;
 import org.shaded.apache.solr.client.solrj.SolrServerException;
 import org.shaded.apache.solr.client.solrj.embedded.EmbeddedSolrServer;
 import org.shaded.apache.solr.common.SolrInputDocument;
@@ -220,8 +217,11 @@ public class SolrRecordWriter<K, V> extends RecordWriter<K, V> {
       }
     }
     throw new IOException(String.format(Locale.ENGLISH,
-            "No local cache archives, where is %s:%s", SolrOutputFormat
-            .getSetupOk(), SolrOutputFormat.getZipName(conf)));
+        "No local cache archives, where is setupOk:%s zipName:%s localArchives:%s outputId:%s",
+        SolrOutputFormat.getSetupOk(),
+        SolrOutputFormat.getZipName(conf),
+        String.join(",", conf.get(MRJobConfig.CACHE_LOCALARCHIVES)),
+        outputId));
   }
 
   /**

--- a/src/main/java/org/apache/solr/hadoop/SolrRecordWriter.java
+++ b/src/main/java/org/apache/solr/hadoop/SolrRecordWriter.java
@@ -54,7 +54,9 @@ public class SolrRecordWriter<K, V> extends RecordWriter<K, V> {
 
   public static final String DEFAULT_CORE_NAME = "core1";
   
-  public static final String SOLR_HOME_DIR =  "solr_home";
+  public static final String SOLR_HOME_DIR = "solr_home";
+
+  public static final String DATA_DIR = "data";
 
   public final static List<String> allowedConfigDirectories = new ArrayList<>(
           Arrays.asList("conf", "lib", "solr.xml", DEFAULT_CORE_NAME));
@@ -141,7 +143,7 @@ public class SolrRecordWriter<K, V> extends RecordWriter<K, V> {
 
     debugLs(conf, solrHomeDir);
 
-    Path solrDataDir = new Path(outputShardDir, "data");
+    Path solrDataDir = new Path(outputShardDir, DATA_DIR);
     
     String dataDirStr = solrDataDir.toUri().toString();
 

--- a/src/main/java/org/apache/solr/hadoop/TreeMergeOutputFormat.java
+++ b/src/main/java/org/apache/solr/hadoop/TreeMergeOutputFormat.java
@@ -219,9 +219,12 @@ public class TreeMergeOutputFormat extends FileOutputFormat<Text, NullWritable> 
             Path solrHomeLocalPath = new Path(tempSolrDir.getAbsolutePath());
             fs.copyToLocalFile(solrHomeDst, solrHomeLocalPath);
 
+            SolrRecordWriter.removeLocalCoreProperties(context.getConfiguration(), new Path(solrHomeLocalPath, SolrRecordWriter.SOLR_HOME_DIR));
+
             // Ensure this directory can be read back without altering hdfs index (cleans up some index files)
             EmbeddedSolrServer solr = SolrRecordWriter.createEmbeddedSolrServerWithHome(context.getConfiguration(), workDir.getParent().getParent(), new Path(solrHomeLocalPath, SolrRecordWriter.SOLR_HOME_DIR));
             solr.close();
+            SolrRecordWriter.removeLocalCoreProperties(context.getConfiguration(), new Path(solrHomeLocalPath, SolrRecordWriter.SOLR_HOME_DIR));
             LOG.info("Successfully read back {}", workDir.getParent().getParent());
             
           }

--- a/src/main/java/org/apache/solr/hadoop/TreeMergeOutputFormat.java
+++ b/src/main/java/org/apache/solr/hadoop/TreeMergeOutputFormat.java
@@ -257,7 +257,7 @@ public class TreeMergeOutputFormat extends FileOutputFormat<Text, NullWritable> 
       LOG.info("Writing shard number file");
       Preconditions.checkArgument(shards.size() > 0);
       String shard = shards.get(0).getParent().getParent().getName(); // move up from "data/index"
-      String taskId = shard.substring("part-m-".length(), shard.length()); // e.g. part-m-00001
+      String taskId = shard.replaceAll("^[^0-9]+", ""); // e.g. part-m-00001 or core2
       int taskNum = Integer.parseInt(taskId);
       int outputShardNum = taskNum / shards.size();
 

--- a/src/main/java/org/apache/solr/hadoop/util/Utils.java
+++ b/src/main/java/org/apache/solr/hadoop/util/Utils.java
@@ -60,6 +60,11 @@ import org.slf4j.LoggerFactory;
 public final class Utils {
 
   private static final String LOG_CONFIG_FILE = "hadoop.log4j.configuration";
+  /**
+   * Used by {@link Utils#listSortedOutputShardDirs(org.apache.hadoop.conf.Configuration, org.apache.hadoop.fs.Path)}
+   * to get the directories containing {@link SolrOutputFormat} indexes
+   */
+  public static final String DIRECTORY_PREFIX_OVERRIDE = "solr-mapreduce-indexer.directory.prefix";
   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   public static void setLogConfigFile(File file, Configuration conf) {
@@ -140,7 +145,8 @@ public final class Utils {
           IOException {
     
     FileSystem fs = outputReduceDir.getFileSystem(conf);
-    final String dirPrefix = SolrOutputFormat.getOutputName(Job.getInstance(conf)); // note this is normally just "part";
+    // use either an override directory prefix OR the part file prefix which is usually `part` or set by "mapreduce.output.basename"
+    final String dirPrefix = conf.get(DIRECTORY_PREFIX_OVERRIDE, SolrOutputFormat.getOutputName(Job.getInstance(conf)));
     FileStatus[] dirs = fs.globStatus(outputReduceDir, (Path path) -> path.getName().startsWith(dirPrefix));
     for (FileStatus dir : dirs) {
       if (!dir.isDirectory()) {


### PR DESCRIPTION
For https://foursquare.atlassian.net/browse/PLPL-5396

This is a part 2 of 2 of a pr into this repo. See #3 

This fixes issues I had running the `IndexMergeTool` with neutronic indexes.

* provide a way to specify part file prefix that isn't just `part-`
* write permission issues in yarn cluster
* problems with core.properties being a problem which I attributed to a solr7 change.
* Expose some constants


Prior to merge:

- [x]  Point at correct destination branch
- [x]  Update release version
- [x] Update to release version of shaded-solr