### PR TITLE
Hofix missing parts (PLPL-5642)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.factual.solr.indexing</groupId>
     <artifactId>solr-mapreduce-indexer</artifactId>
     <name>solr-mapreduce-indexer</name>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.1</version>
     <dependencies>    
         <dependency>
             <groupId>net.sourceforge.argparse4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.factual.solr.indexing</groupId>
     <artifactId>solr-mapreduce-indexer</artifactId>
     <name>solr-mapreduce-indexer</name>
-    <version>1.0.0</version>
+    <version>1.0.1-SNAPSHOT</version>
     <dependencies>    
         <dependency>
             <groupId>net.sourceforge.argparse4j</groupId>

--- a/src/main/java/org/apache/solr/hadoop/TreeMergeOutputFormat.java
+++ b/src/main/java/org/apache/solr/hadoop/TreeMergeOutputFormat.java
@@ -256,13 +256,9 @@ public class TreeMergeOutputFormat extends FileOutputFormat<Text, NullWritable> 
     private void writeShardNumberFile(TaskAttemptContext context) throws IOException {
       LOG.info("Writing shard number file");
       Preconditions.checkArgument(shards.size() > 0);
-      String shard = shards.get(0).getParent().getParent().getName(); // move up from "data/index"
-      String taskId = shard.replaceAll("^[^0-9]+", ""); // e.g. part-m-00001 or core2
-      int taskNum = Integer.parseInt(taskId);
-      int outputShardNum = taskNum / shards.size();
-
+      int outputShardNum = context.getTaskAttemptID().getTaskID().getId();
       Path shardNumberFile = new Path(workDir.getParent().getParent(), TreeMergeMapper.SOLR_SHARD_NUMBER);
-      LOG.info("Merging into outputShardNum: " + outputShardNum + " from taskId: " + taskId + "at path: " + shardNumberFile);
+      LOG.info(String.format("Merging %d shards in shard %d path: %s", shards.size(), outputShardNum, shardNumberFile));
 
       OutputStream out = shardNumberFile.getFileSystem(context.getConfiguration()).create(shardNumberFile);
       try (Writer writer = new OutputStreamWriter(out, StandardCharsets.UTF_8)) {


### PR DESCRIPTION
For [PLPL-5642](https://foursquare.atlassian.net/browse/PLPL-5642)

Indexes missing after merge, e.g. `part-m-00010` was missing (overwriting `part-m-00001`).